### PR TITLE
Lazy process map

### DIFF
--- a/src/proc_utils/io.rs
+++ b/src/proc_utils/io.rs
@@ -39,7 +39,7 @@ fn get_process_metadata(dir_path: PathBuf) -> ProcessInformation {
     assert_eq!(stat_fields.len(), 52,
                "Expected {} metadata fields, found {}", 52, stat_fields.len());
 
-    ProcessInformation::new_from_stat(&stat_fields)
+    ProcessInformation::new_from_stat(&stat_fields, true)
 }
 
 pub fn get_pid_info(pid: u64) -> io::Result<ProcessInformation> {

--- a/src/proc_utils/process/memory.rs
+++ b/src/proc_utils/process/memory.rs
@@ -197,9 +197,6 @@ impl MemoryRegion {
             .map(PageFrame::new)
             .zip(page_index_start..page_index_end);
 
-        // iterate over the values and find consecutive mappings to store in our map
-        let mut physical_address: Option<(usize, usize)> = None;
-
         // check if the iterator is empty, and if so, terminate early
         let first_page = page_frames.next();
         if first_page.is_none() {
@@ -265,5 +262,9 @@ impl MemoryRegion {
             permissions,
             physical_regions: None,
         }
+    }
+
+    pub fn has_physical_mapping(&self) -> bool {
+        return self.physical_regions.is_some();
     }
 }

--- a/src/proc_utils/process/mod.rs
+++ b/src/proc_utils/process/mod.rs
@@ -65,6 +65,7 @@ impl ProcessMemoryMap {
         let mut maps_file = File::open(&maps_path)
             .expect(&format!("Could not open file '{}'", maps_path));
 
+        // check if we want to and if we even can read the physical pagemap
         let mut pagemap_option = {
             if !map_physical {
                 None
@@ -119,12 +120,12 @@ pub struct ProcessInformation {
     state: ProcessState,
 
     // The mapped memory of the process.
-    memory: ProcessMemoryMap,
+    memory: Option<ProcessMemoryMap>,
 }
 
 impl ProcessInformation {
     /// Construct a new `ProcessInformation` from the parsed fields of `/proc/[pid]/stat`
-    pub fn new_from_stat(stat_fields: &Vec<String>) -> Self {
+    pub fn new_from_stat(stat_fields: &Vec<String>, preload_mapping: bool) -> Self {
         let pid = stat_fields[0].parse::<usize>().unwrap();
 
         ProcessInformation {
@@ -132,11 +133,28 @@ impl ProcessInformation {
             comm: stat_fields[1].clone(),
             state: ProcessState::new_from_code(stat_fields[2].chars().next().unwrap()),
 
-            memory: ProcessMemoryMap::new_memory_map(pid, true),
+            memory: match preload_mapping {
+                true => Some(ProcessMemoryMap::new_memory_map(pid, true)),
+                false => None,
+            },
         }
     }
 
+    pub fn memory(&mut self) -> &ProcessMemoryMap {
+        self.memory.get_or_insert(ProcessMemoryMap::new_memory_map(self.pid, true))
+    }
+
     pub fn has_physical_map(&self) -> bool {
-        self.memory.regions.last().is_some()
+        // if no memory mapping has been computed yet, return false
+        if self.memory.is_none() {
+            return false;
+        }
+
+        // else check if a physical mapping is available (at least for some region)
+        return self.memory.as_ref().unwrap().regions.iter().any(
+            |ref region| {
+                region.has_physical_mapping()
+            }
+        );
     }
 }

--- a/src/proc_utils/process/mod.rs
+++ b/src/proc_utils/process/mod.rs
@@ -23,6 +23,8 @@ pub enum ProcessState {
     Tracing,
     // X
     Dead,
+    // I
+    Idle,
 }
 
 impl ProcessState {
@@ -35,6 +37,7 @@ impl ProcessState {
             'T' => ProcessState::Stopped,
             't' => ProcessState::Tracing,
             'X' => ProcessState::Dead,
+            'I' => ProcessState::Idle,
             _ => panic!("Invalid state code '{}' encountered", state_code)
         }
     }


### PR DESCRIPTION
For potential real-time applications (like a process viewer) I want to be able to create a view of the process metadata without having to scan the whole memory mapping. So I added an argument `preload_mapping` in the `ProcessInformation` constructor so that the mapping can be ignored at construction time. It can still be accessed via the function `ProcessInformation.memory()` which will transparently load the mapping if it doesn't exist, so nothing changes functionality-wise.

Also fixed a small missing process state that has been introduced in newer kernels.